### PR TITLE
Added action for changeattributeset to resolve 404 when trying to change...

### DIFF
--- a/app/code/community/TBT/Enhancedgrid/controllers/Catalog/ProductController.php
+++ b/app/code/community/TBT/Enhancedgrid/controllers/Catalog/ProductController.php
@@ -151,4 +151,50 @@ class TBT_Enhancedgrid_Catalog_ProductController extends Mage_Adminhtml_Catalog_
         $this->_redirect('*/*/index');
     }
 
+    // Added by Tegan Snyder. 
+    public function changeattributesetAction() {
+
+        $productIds = $this->getRequest()->getParam('product');
+        $storeId = (int)$this->getRequest()->getParam('store', 0);
+
+        // todo make sure store is set... check a post data below
+        // $postData = Mage::app()->getRequest()->getPost();
+        // echo '<pre>';
+        // print_r($postData);
+        // echo '</pre>';
+
+        if(!is_array($productIds)) {
+
+            $this->_getSession()->addError($this->__('Please select product(s)'));
+       
+        } else {
+
+            try {
+
+                foreach ($productIds as $productId) {
+
+                    $product = Mage::getSingleton('catalog/product')
+                    ->unsetData()
+                    ->setStoreId($storeId)
+                    ->load($productId)
+                    ->setAttributeSetId($this->getRequest()->getParam('attribute_set'))
+                    ->setIsMassupdate(true)
+                    ->save();
+                }
+
+                Mage::dispatchEvent('catalog_product_massupdate_after', array('products'=>$productIds));
+                $this->_getSession()->addSuccess(
+                $this->__('Total of %d record(s) were successfully updated', count($productIds)));
+
+            } catch (Exception $e) {
+
+                $this->_getSession()->addError($e->getMessage());
+            }
+
+        }
+
+        $this->_redirect('*/*/', array('store'=>(int)$this->getRequest()->getParam('store', 0)));
+
+    }
+
 }


### PR DESCRIPTION
... attribute set

I was getting 404 pages when trying to update attribute sets with this extension and noticed that the action for changeattributeset didn't exist in the extension nor did it exist in Mage_Adminhtml_Catalog_ProductController on Magento EE ver. 1.13.0.1
