### PR TITLE
Event from core added to _prepareMassaction

### DIFF
--- a/app/code/community/TBT/Enhancedgrid/Block/Catalog/Product/Grid.php
+++ b/app/code/community/TBT/Enhancedgrid/Block/Catalog/Product/Grid.php
@@ -574,6 +574,9 @@ class TBT_Enhancedgrid_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_W
                     '_current' => true,
                 )),
             ));
+            
+        // enable other modules to add mass action
+        Mage::dispatchEvent('adminhtml_catalog_product_grid_prepare_massaction', array('block' => $this));
 
         // Divider
         $this->getMassactionBlock()->addItem('imagesDivider', $this->getMADivider('Images'));


### PR DESCRIPTION
To keep the possibility to add other mass action to the grid, the event "adminhtml_catalog_product_grid_prepare_massaction" needs to be dispatched anywhere in the method