### PR TITLE
Removed version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "jayelkaake/enhancedgrid",
     "type": "magento-module",
-    "version": "1.3.4.3",
     "description":"Improves the existing Magento admin product management grid. It adds some useful, customizable features to the admin product management grid including new columns and tools.",
     "authors":[
         {


### PR DESCRIPTION
I had problem with updating to v1.3.4.4 via composer. Here is errors, which shows me, when I run composer update with:
`Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - The requested package jayelkaake/enhancedgrid v1.3.4.4 exists as jayelkaake/enhancedgrid[1.3.4.2, 1.3.4.3] but these are rejected by your constraint.`

The reason of this problem was, that tagged version and version in composer.json are different. Tagged version is "v1.3.4.4", but in composer.json is "1.3.4.3". I read the composer docs and there is such advice:

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.
Source: https://getcomposer.org/doc/04-schema.md#version

So I removed "version" from composer.json.