### PR TITLE
Use generated thumbnail image instead of original image file

### DIFF
--- a/app/code/community/TBT/Enhancedgrid/Block/Widget/Grid/Column/Renderer/Image.php
+++ b/app/code/community/TBT/Enhancedgrid/Block/Widget/Grid/Column/Renderer/Image.php
@@ -80,7 +80,7 @@ class TBT_Enhancedgrid_Block_Widget_Grid_Column_Renderer_Image extends Mage_Admi
         $val = $val2 = $row->getData($this->getColumn()->getIndex());
         $val = str_replace('no_selection', '', $val);
         $val2 = str_replace('no_selection', '', $val2);
-        $url = Mage::helper('enhancedgrid')->getImageUrl($val);
+        $url = Mage::helper('enhancedgrid')->getImageUrl($val, $row);
 
         if (!Mage::helper('enhancedgrid')->getFileExists($val)) {
             $dored = true;

--- a/app/code/community/TBT/Enhancedgrid/Helper/Data.php
+++ b/app/code/community/TBT/Enhancedgrid/Helper/Data.php
@@ -2,11 +2,23 @@
 
 class TBT_Enhancedgrid_Helper_Data extends Mage_Core_Helper_Abstract
 {
-    public function getImageUrl($image_file)
+    /**
+     * Get url of cached thumbnail image
+     * Will generate cached image if doesn't exist
+     *
+     * @param  string  $image_file
+     * @param  Mage_Catalog_Model_Product  $product
+     * @return bool|string
+     */
+    public function getImageUrl($image_file, $product)
     {
         $url = false;
-        $url = Mage::getBaseUrl('media').'catalog/product'.$image_file;
-
+        if (!empty($image_file)) {
+            $helper = Mage::helper('catalog/image')->init($product, 'thumbnail');
+            $width = Mage::getStoreConfig( 'enhancedgrid/images/width');
+            $height = Mage::getStoreConfig( 'enhancedgrid/images/height');
+            $url = $helper->resize($width, $height)->__toString();
+        }
         return $url;
     }
 


### PR DESCRIPTION
This PR modifies the image url used in the product grid to be a generated file resized to the dimensions of the config settings (_enhancedgrid/images/width_ and _enhancedgrid/images/height_).   This helps thumbnails load much more quickly if the originals are large.  It also constrains thumbnails to a square helping to maintain the grid layout when non-square images get uploaded as shown in the screenshots below.

**Before:**
![screen shot 2019-02-15 at 5 13 03 pm](https://user-images.githubusercontent.com/281482/52887248-03eed900-3145-11e9-9e65-766ba84712a6.png)
 
**After:**
![screen shot 2019-02-15 at 5 12 52 pm](https://user-images.githubusercontent.com/281482/52887261-0ea96e00-3145-11e9-9f18-342234cfec3e.png)
